### PR TITLE
use document.body instead of getElementsByTagName

### DIFF
--- a/generated_toc.js
+++ b/generated_toc.js
@@ -136,7 +136,7 @@ generated_toc = {
     // set top_node to be the element in the document under which
     // we'll be analysing headings
     if (generate_for == 'page') {
-      top_node = document.getElementsByTagName('body');
+      top_node = document.body;
     } else {
       // i.e., explicitly set to "parent", left blank (so "unset"),
       // or some invalid value


### PR DESCRIPTION
"document.getElementsByTagName('body')" will return an array, which will cause an error when configed as "generate_for_page" at line 171 on Firefox: top_node.getElementsByTagName('*').

Because an array doesn't have function "getElementsByTagName".

The correct usage should be "document.getElementsByTagName('body')[0]" , or as I write, "document.body"
