### PR TITLE
Add SameSite=strict to cookies

### DIFF
--- a/generated_toc.js
+++ b/generated_toc.js
@@ -341,7 +341,7 @@ generated_toc = {
       var expires = "; expires="+date.toGMTString();
     }
     else var expires = "";
-    document.cookie = name+"="+value+expires+"; path=/; SameSite=strict";
+    document.cookie = name+"="+value+expires+"; path=/; SameSite=strict; Secure";
   },
 
   readCookie: function(name) {

--- a/generated_toc.js
+++ b/generated_toc.js
@@ -341,7 +341,7 @@ generated_toc = {
       var expires = "; expires="+date.toGMTString();
     }
     else var expires = "";
-    document.cookie = name+"="+value+expires+"; path=/";
+    document.cookie = name+"="+value+expires+"; path=/; SameSite=strict";
   },
 
   readCookie: function(name) {


### PR DESCRIPTION
Addresses error message seen in JavaScript console on Firefox. It says:

Cookie “generated_toc_display” will be soon rejected because it has the “SameSite” attribute set to “None” or an invalid value, without the “secure” attribute. To know more about the “SameSite“ attribute, read https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite | generated_toc.js:270:4

Fix: Add property `SameSite=strict; Secure` to createCookie function.